### PR TITLE
Use new cf-runtime-stacks bucket to fetch rootfs

### DIFF
--- a/site-cookbooks/warden/recipes/rootfs.rb
+++ b/site-cookbooks/warden/recipes/rootfs.rb
@@ -1,4 +1,4 @@
-root_fs_url = "http://cfstacks.s3.amazonaws.com/lucid64.dev.tgz"
+root_fs_url = "http://cf-runtime-stacks.s3.amazonaws.com/lucid64.dev.tgz"
 root_fs_checksum = "b2633b2ab4964f91402bb2d889f2f12449a8b828"
 
 src_filename = File.basename(root_fs_url)


### PR DESCRIPTION
We changed the bucket where we store the rootfs bits. No change to the rootfs itself was made.

https://www.pivotaltracker.com/story/show/81240816
