### PR TITLE
Faster info

### DIFF
--- a/old/linux_backend/linux_container.go
+++ b/old/linux_backend/linux_container.go
@@ -201,10 +201,6 @@ func (c *LinuxContainer) GraceTime() time.Duration {
 	return c.graceTime
 }
 
-func (c *LinuxContainer) Properties() garden.Properties {
-	return c.properties
-}
-
 func (c *LinuxContainer) State() State {
 	c.stateMutex.RLock()
 	defer c.stateMutex.RUnlock()
@@ -450,6 +446,13 @@ func (c *LinuxContainer) Stop(kill bool) error {
 	return nil
 }
 
+func (c *LinuxContainer) Properties() garden.Properties {
+	c.propertiesMutex.RLock()
+	defer c.propertiesMutex.RUnlock()
+
+	return c.properties
+}
+
 func (c *LinuxContainer) GetProperty(key string) (string, error) {
 	c.propertiesMutex.RLock()
 	defer c.propertiesMutex.RUnlock()
@@ -466,11 +469,14 @@ func (c *LinuxContainer) SetProperty(key string, value string) error {
 	c.propertiesMutex.Lock()
 	defer c.propertiesMutex.Unlock()
 
-	if c.properties == nil {
-		c.properties = make(map[string]string)
+	props := garden.Properties{}
+	for k, v := range c.properties {
+		props[k] = v
 	}
 
-	c.properties[key] = value
+	props[key] = value
+
+	c.properties = props
 
 	return nil
 }
@@ -484,7 +490,15 @@ func (c *LinuxContainer) RemoveProperty(key string) error {
 		return UndefinedPropertyError{key}
 	}
 
-	delete(c.properties, key)
+	props := garden.Properties{}
+	for k, v := range c.properties {
+		if k == key {
+			continue
+		}
+		props[k] = v
+	}
+
+	c.properties = props
 
 	return nil
 }

--- a/old/linux_backend/linux_container.go
+++ b/old/linux_backend/linux_container.go
@@ -526,10 +526,10 @@ func (c *LinuxContainer) Info() (garden.ContainerInfo, error) {
 		return garden.ContainerInfo{}, err
 	}
 
-	bandwidthStat, err := c.bandwidthManager.GetLimits(cLog)
-	if err != nil {
-		return garden.ContainerInfo{}, err
-	}
+	// bandwidthStat, err := c.bandwidthManager.GetLimits(cLog)
+	// if err != nil {
+	// 	return garden.ContainerInfo{}, err
+	// }
 
 	mappedPorts := []garden.PortMapping{}
 
@@ -558,8 +558,8 @@ func (c *LinuxContainer) Info() (garden.ContainerInfo, error) {
 		MemoryStat:    parseMemoryStat(memoryStat),
 		CPUStat:       parseCPUStat(cpuUsage, cpuStat),
 		DiskStat:      diskStat,
-		BandwidthStat: bandwidthStat,
-		MappedPorts:   mappedPorts,
+		// BandwidthStat: bandwidthStat,
+		MappedPorts: mappedPorts,
 	}
 
 	c.Resources().Network.Info(&info)

--- a/old/linux_backend/linux_container_test.go
+++ b/old/linux_backend/linux_container_test.go
@@ -2253,40 +2253,40 @@ system 2
 			})
 		})
 
-		Describe("bandwidth info", func() {
-			It("is returned in the response", func() {
-				fakeBandwidthManager.GetLimitsResult = garden.ContainerBandwidthStat{
-					InRate:   1,
-					InBurst:  2,
-					OutRate:  3,
-					OutBurst: 4,
-				}
+		// Describe("bandwidth info", func() {
+		// 	It("is returned in the response", func() {
+		// 		fakeBandwidthManager.GetLimitsResult = garden.ContainerBandwidthStat{
+		// 			InRate:   1,
+		// 			InBurst:  2,
+		// 			OutRate:  3,
+		// 			OutBurst: 4,
+		// 		}
 
-				info, err := container.Info()
-				Ω(err).ShouldNot(HaveOccurred())
+		// 		info, err := container.Info()
+		// 		Ω(err).ShouldNot(HaveOccurred())
 
-				Ω(info.BandwidthStat).Should(Equal(garden.ContainerBandwidthStat{
-					InRate:   1,
-					InBurst:  2,
-					OutRate:  3,
-					OutBurst: 4,
-				}))
+		// 		Ω(info.BandwidthStat).Should(Equal(garden.ContainerBandwidthStat{
+		// 			InRate:   1,
+		// 			InBurst:  2,
+		// 			OutRate:  3,
+		// 			OutBurst: 4,
+		// 		}))
 
-			})
+		// 	})
 
-			Context("when getting the bandwidth usage fails", func() {
-				disaster := errors.New("oh no!")
+		// 	Context("when getting the bandwidth usage fails", func() {
+		// 		disaster := errors.New("oh no!")
 
-				JustBeforeEach(func() {
-					fakeBandwidthManager.GetLimitsError = disaster
-				})
+		// 		JustBeforeEach(func() {
+		// 			fakeBandwidthManager.GetLimitsError = disaster
+		// 		})
 
-				It("returns the error", func() {
-					_, err := container.Info()
-					Ω(err).Should(Equal(disaster))
-				})
-			})
-		})
+		// 		It("returns the error", func() {
+		// 			_, err := container.Info()
+		// 			Ω(err).Should(Equal(disaster))
+		// 		})
+		// 	})
+		// })
 	})
 })
 


### PR DESCRIPTION
This removes the bandwidth stats from the container Info call, as we have found that they prevent Diego from performing adequately with many containers running in garden-linux.

We also changed the container property modifications to be copy-on-write, as the previous implementation gave out references to a map that could later be mutated unexpectedly.

This is associated to [this Diego story](https://www.pivotaltracker.com/story/show/88539102).

Thanks,
@ematpl && @fraenkel 