### PR TITLE
Fixed network namespace leak

### DIFF
--- a/old/linux_backend/skeleton/lib/hook-parent-after-clone.sh
+++ b/old/linux_backend/skeleton/lib/hook-parent-after-clone.sh
@@ -105,6 +105,7 @@ ip netns exec $PID ./bin/container-net -target=container \
                 -subnet=$network_cidr \
                 -mtu=$container_iface_mtu
 
+rm -f /var/run/netns/$PID
 umount /sys
 
 exit 0


### PR DESCRIPTION
when libcontainer's netlink.NetworkSetNsPid is called, the network
namespace is created and attached with the pid. But this network
namespace persists even after the pid is killed. So we need to
explicitly delete these network namespaces, otherwise they get
piled up over time.