### PR TITLE
better error message when failing to fetch docker image

### DIFF
--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client.go
@@ -69,6 +69,15 @@ func (err ContainerNotFoundError) Error() string {
 	return fmt.Sprintf("unknown handle: %s", err.Handle)
 }
 
+type FailedToFetchError struct {
+	Cause error
+}
+
+func (err FailedToFetchError) Error() string {
+	//	return fmt.Sprintf("could not fetch: %s image from %s registry: %s", err.Reponame, err.Hostname, err.Cause.Error())
+	return err.Cause.Error()
+}
+
 // ContainerSpec specifies the parameters for creating a container. All parameters are optional.
 type ContainerSpec struct {
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client/connection/connection.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client/connection/connection.go
@@ -619,6 +619,11 @@ func (c *connection) doStream(
 			return nil, fmt.Errorf("bad response: %s", httpResp.Status)
 		}
 
+		if httpResp.StatusCode == 412 {
+			//the body has the actual error string formed at the server
+			return nil, errors.New(string(errResponse))
+		}
+
 		return nil, Error{httpResp.StatusCode, string(errResponse)}
 	}
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client/connection/connection_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/client/connection/connection_test.go
@@ -108,6 +108,22 @@ var _ = Describe("Connection", func() {
 				Ω(err).Should(HaveOccurred())
 			})
 		})
+
+		Context("when the request fails with special error code 412", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/ping"),
+						ghttp.RespondWith(412, "Special Error Message"),
+					),
+				)
+			})
+
+			It("should return an error sans http info in the error message", func() {
+				err := connection.Ping()
+				Ω(err).Should(MatchError("Special Error Message"))
+			})
+		})
 	})
 
 	Describe("Getting capacity", func() {

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/server/request_handling.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/server/request_handling.go
@@ -1043,7 +1043,9 @@ func (s *GardenServer) writeError(w http.ResponseWriter, err error, logger lager
 	logger.Error("failed", err)
 
 	statusCode := http.StatusInternalServerError
-	if _, ok := err.(garden.ContainerNotFoundError); ok {
+	if _, ok := err.(garden.FailedToFetchError); ok {
+		statusCode = 412
+	} else if _, ok := err.(garden.ContainerNotFoundError); ok {
 		statusCode = http.StatusNotFound
 	}
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/server/request_handling_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/server/request_handling_test.go
@@ -244,6 +244,20 @@ var _ = Describe("When a client connects", func() {
 				Ω(err).Should(HaveOccurred())
 			})
 		})
+		Context("when creating the container fails for special error type", func() {
+			BeforeEach(func() {
+				serverBackend.CreateReturns(nil, garden.FailedToFetchError{
+					errors.New("special error"),
+				})
+			})
+
+			It("client returns an error with a well formed error msg", func() {
+				_, err := apiClient.Create(garden.ContainerSpec{
+					Handle: "some-handle",
+				})
+				Ω(err).Should(MatchError("special error"))
+			})
+		})
 	})
 
 	Context("and the client sends a destroy request", func() {

--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -44,6 +44,20 @@ var _ = Describe("Creating a container", func() {
 		})
 	})
 
+	Describe("Docker image download in a container", func() {
+		It("returns a helpful error message when image not found from default registry", func() {
+			client = startGarden()
+			_, err := client.Create(garden.ContainerSpec{RootFSPath: "docker:///cloudfoundry/doesnotexist"})
+			Expect(err.Error()).To(ContainSubstring("could not fetch cloudfoundry/doesnotexist image from https://index.docker.io/v1/ registry"))
+		})
+
+		It("returns a helpful error message when image not found from custom registry", func() {
+			client = startGarden()
+			_, err := client.Create(garden.ContainerSpec{RootFSPath: "docker://example.com/cloudfoundry/doesnotexist"})
+			Expect(err.Error()).To(ContainSubstring("could not fetch cloudfoundry/doesnotexist image from example.com registry"))
+		})
+	})
+
 	Describe("concurrently destroying", func() {
 		allBridges := func() []byte {
 			stdout := gbytes.NewBuffer()

--- a/old/repository_fetcher/repository_fetcher.go
+++ b/old/repository_fetcher/repository_fetcher.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudfoundry-incubator/garden"
 	"github.com/cloudfoundry-incubator/garden-linux/process"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
@@ -30,9 +31,17 @@ type Registry interface {
 	GetRepositoryData(repoName string) (*registry.RepositoryData, error)
 	GetRemoteTags(registries []string, repository string, token []string) (map[string]string, error)
 	GetRemoteHistory(imageID string, registry string, token []string) ([]string, error)
-
 	GetRemoteImageJSON(imageID string, registry string, token []string) ([]byte, int, error)
 	GetRemoteImageLayer(imageID string, registry string, token []string, size int64) (io.ReadCloser, error)
+}
+
+type RegistryStringer struct {
+	*registry.Session // inherit all the registry methods (Session as receiver on methods)
+	endpoint          string
+}
+
+func (r RegistryStringer) String() string {
+	return r.endpoint
 }
 
 // apes docker's *graph.Graph
@@ -86,6 +95,11 @@ func New(registry RegistryProvider, graph Graph) RepositoryFetcher {
 	}
 }
 
+func (fetcher *DockerRepositoryFetcher) CommonError(registry Registry, reponame string, err error) error {
+	tmpErr := fmt.Errorf("repository fetcher: could not fetch %s image from %v registry: %s", reponame, registry, err)
+	return garden.FailedToFetchError{Cause: tmpErr}
+}
+
 func (fetcher *DockerRepositoryFetcher) Fetch(
 	logger lager.Logger,
 	repoURL *url.URL,
@@ -101,12 +115,12 @@ func (fetcher *DockerRepositoryFetcher) Fetch(
 	registry, err := fetcher.registryProvider.ProvideRegistry(repoURL.Host)
 	if err != nil {
 		logger.Error("failed-to-construct-registry-endpoint", err)
-		return "", nil, nil, err
+		return "", nil, nil, fetcher.CommonError(registry, repoURL.Path[1:], err)
 	}
 
 	repoData, err := registry.GetRepositoryData(repoURL.Path[1:])
 	if err != nil {
-		return "", nil, nil, err
+		return "", nil, nil, fetcher.CommonError(registry, repoURL.Path[1:], err)
 	}
 
 	tagsList, err := registry.GetRemoteTags(repoData.Endpoints, repoURL.Path[1:], repoData.Tokens)
@@ -116,7 +130,7 @@ func (fetcher *DockerRepositoryFetcher) Fetch(
 
 	imgID, ok := tagsList[tag]
 	if !ok {
-		return "", nil, nil, fmt.Errorf("unknown tag: %s:%s", repoURL, tag)
+		return "", nil, nil, fetcher.CommonError(registry, repoURL.Path[1:], fmt.Errorf("unknown tag: %v:", tag))
 	}
 
 	token := repoData.Tokens
@@ -140,7 +154,7 @@ func (fetcher *DockerRepositoryFetcher) Fetch(
 		}
 	}
 
-	return "", nil, nil, fmt.Errorf("all endpoints failed: %v", err)
+	return "", nil, nil, fetcher.CommonError(registry, repoURL.Path[1:], fmt.Errorf("all endpoints failed: %v", err))
 }
 
 func (fetcher *DockerRepositoryFetcher) fetchFromEndpoint(logger lager.Logger, registry Registry, endpoint string, imgID string, token []string) (*dockerImage, error) {


### PR DESCRIPTION
The docker image fetch can fail at several stages;
Formed a common message using below scheme
 - docker url would be docker://registry/dockeruser/reponame:tag
 - repo/image name will be identified as dockeruser/reponame

Appended the lower level error message in the error string, for user clarity.

Have taken the test cases from acceptance, but modified to include the lower level error message (substring)

Also, have used 412 - HTTP precondition failed.
The same (or any other error code) can be used for similar errors which need info from server, but needn't include http details.

If this implementation is flawed, please feel free to reject this PR and suggest the alternate. I would be more then willing to update the implementation.

reference
[#89007566]