### PR TITLE
Error gracefully when setting CWD to non-existent working directory during Run command

### DIFF
--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -703,6 +703,22 @@ var _ = Describe("Creating a container", func() {
 				})
 			})
 
+			Context("with a working directory that does not exist", func() {
+				It("changing to given directory fails, process returns with exit status 255 and provides proper error message in stderr", func() {
+					stderr := gbytes.NewBuffer()
+
+					process, err := container.Run(garden.ProcessSpec{
+						Path: "sh",
+						Dir:  "/asdf",
+					}, garden.ProcessIO{
+						Stderr: stderr,
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(stderr).Should(gbytes.Say("ERROR: failed to change directory to /asdf: No such file or directory"))
+					Expect(process.Wait()).To(Equal(255))
+				})
+			})
+
 			Context("and then attaching to it", func() {
 				It("streams output and the exit status to the attached request", func(done Done) {
 					stdout1 := gbytes.NewBuffer()

--- a/old/linux_backend/src/wsh/wshd.c
+++ b/old/linux_backend/src/wsh/wshd.c
@@ -376,7 +376,7 @@ int child_fork(msg_request_t *req, int in, int out, int err) {
     if (strlen(req->dir.path)) {
       rv = chdir(req->dir.path);
       if (rv == -1) {
-        perror("chdir");
+        fprintf(stderr, "ERROR: failed to change directory to %s: %s", req->dir.path, strerror(errno));
         goto error;
       }
     }


### PR DESCRIPTION
this refers to the story [#84690384]
currently wshd returns 255 for many such errors, a better option would be to at-least return errno in place; for better utility to users. If Ok I can update the same. 

Also, the story refers to another point where container.run() could also return err with similar information (the one put on stderr). In my opinion this might not be Ok; as the user of container.run() is supposed to wait on the returned process, which eventually tells if the process executed successfully or not. If there is an alternate suggestion, please let me know and I would gladly update this implementation.