### PR TITLE
Adding network statistics to container metrics

### DIFF
--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/container.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/garden/container.go
@@ -228,9 +228,10 @@ type ContainerInfoEntry struct {
 }
 
 type Metrics struct {
-	MemoryStat ContainerMemoryStat
-	CPUStat    ContainerCPUStat
-	DiskStat   ContainerDiskStat
+	MemoryStat  ContainerMemoryStat
+	CPUStat     ContainerCPUStat
+	DiskStat    ContainerDiskStat
+	NetworkStat ContainerNetworkStat
 }
 
 type ContainerMetricsEntry struct {
@@ -288,6 +289,11 @@ type ContainerBandwidthStat struct {
 	InBurst  uint64
 	OutRate  uint64
 	OutBurst uint64
+}
+
+type ContainerNetworkStat struct {
+	RxBytes   uint64
+	TxBytes   uint64
 }
 
 type BandwidthLimits struct {

--- a/container_pool/container_pool.go
+++ b/container_pool/container_pool.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudfoundry-incubator/garden-linux/linux_container"
 	"github.com/cloudfoundry-incubator/garden-linux/network"
 	"github.com/cloudfoundry-incubator/garden-linux/network/bridgemgr"
+	"github.com/cloudfoundry-incubator/garden-linux/network/devices"
 	"github.com/cloudfoundry-incubator/garden-linux/network/iptables"
 	"github.com/cloudfoundry-incubator/garden-linux/network/subnets"
 	"github.com/cloudfoundry-incubator/garden-linux/old/bandwidth_manager"
@@ -262,7 +263,8 @@ func (p *LinuxContainerPool) Create(spec garden.ContainerSpec) (c linux_backend.
 		"rootfs-env": rootFSEnv,
 		"create-env": specEnv,
 	})
-	return linux_container.NewLinuxContainer(
+
+	container := linux_container.NewLinuxContainer(
 		pLog,
 		id,
 		handle,
@@ -278,7 +280,10 @@ func (p *LinuxContainerPool) Create(spec garden.ContainerSpec) (c linux_backend.
 		process_tracker.New(containerPath, p.runner),
 		rootFSEnv.Merge(specEnv),
 		p.filterProvider.ProvideFilter(id),
-	), nil
+	)
+	container.NetworkStatisticser = devices.Link{Name: p.sysconfig.NetworkInterfacePrefix + id + "-0"}
+
+	return container, nil
 }
 
 func (p *LinuxContainerPool) Restore(snapshot io.Reader) (linux_backend.Container, error) {

--- a/linux_backend/linux_backend.go
+++ b/linux_backend/linux_backend.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"syscall"
 	"time"
 
 	"github.com/cloudfoundry-incubator/garden"
@@ -112,6 +113,10 @@ func (b *LinuxBackend) Start() error {
 
 	for _, container := range containers {
 		keep[container.ID()] = true
+	}
+
+	if err := mountSysFs(); err != nil {
+		return err
 	}
 
 	return b.containerPool.Prune(keep)
@@ -328,4 +333,26 @@ func toGardenContainers(cs []Container) []garden.Container {
 	}
 
 	return result
+}
+
+func mountSysFs() error {
+	mntpoint, err := os.Stat("/sys")
+	if err != nil {
+		return err
+	}
+
+	parent, err := os.Stat("/")
+	if err != nil {
+		return err
+	}
+
+	//mount sysfs if not mounted already
+	if mntpoint.Sys().(*syscall.Stat_t).Dev == parent.Sys().(*syscall.Stat_t).Dev {
+		err = syscall.Mount("sysfs", "/sys", "sysfs", uintptr(0), "")
+		if err != nil {
+			return fmt.Errorf("Mounting sysfs failed: %s", err)
+		}
+	}
+
+	return nil
 }

--- a/linux_container/linux_container.go
+++ b/linux_container/linux_container.go
@@ -93,6 +93,10 @@ type LinuxContainer struct {
 	env process.Env
 
 	processIDPool *ProcessIDPool
+
+	NetworkStatisticser interface {
+		Statistics() (stats garden.ContainerNetworkStat, err error)
+	}
 }
 
 type ProcessIDPool struct {

--- a/linux_container/metrics.go
+++ b/linux_container/metrics.go
@@ -31,10 +31,21 @@ func (c *LinuxContainer) Metrics() (garden.Metrics, error) {
 		return garden.Metrics{}, err
 	}
 
+	hostNetworkStat, err := c.NetworkStatisticser.Statistics()
+	if err != nil {
+		return garden.Metrics{}, err
+	}
+
+	// tx for host_intf is rx for cont_intf and vice-versa
+	var contNetworkStat garden.ContainerNetworkStat
+	contNetworkStat.RxBytes = hostNetworkStat.TxBytes
+	contNetworkStat.TxBytes = hostNetworkStat.RxBytes
+
 	return garden.Metrics{
-		MemoryStat: parseMemoryStat(memoryStat),
-		CPUStat:    parseCPUStat(cpuUsage, cpuStat),
-		DiskStat:   diskStat,
+		MemoryStat:  parseMemoryStat(memoryStat),
+		CPUStat:     parseCPUStat(cpuUsage, cpuStat),
+		DiskStat:    diskStat,
+		NetworkStat: contNetworkStat,
 	}, nil
 }
 

--- a/network/devices/fakedevices/fakes.go
+++ b/network/devices/fakedevices/fakes.go
@@ -1,6 +1,7 @@
 package fakedevices
 
 import "net"
+import "github.com/cloudfoundry-incubator/garden"
 
 type FaveVethCreator struct {
 	CreateCalledWith struct {
@@ -51,6 +52,7 @@ type FakeLink struct {
 	AddDefaultGWReturns error
 	SetMTUReturns       error
 	SetNsReturns        error
+	StatisticsReturns   error
 }
 
 func (f *FakeLink) AddIP(intf *net.Interface, ip net.IP, subnet *net.IPNet) error {
@@ -91,6 +93,17 @@ func (f *FakeLink) InterfaceByName(name string) (*net.Interface, bool, error) {
 	}
 
 	return nil, false, nil
+}
+
+func (f *FakeLink) Statistics() (garden.ContainerNetworkStat, error) {
+	if f.StatisticsReturns != nil {
+		return garden.ContainerNetworkStat{}, f.StatisticsReturns
+	}
+
+	return garden.ContainerNetworkStat{
+		RxBytes: 1,
+		TxBytes: 2,
+	}, nil
 }
 
 type FakeBridge struct {


### PR DESCRIPTION
Network statistics for containers is read from sysfs. Now we can get data such as no.of.bytes, packets, error and dropped packets both recieved and transferred from the container. The code is picked from docker's libcontainer.

I did also check the performance impact and found that the implementation takes very little time to collect the network statistics.