### PR TITLE
useful error returned on container.run, if invoked with a nonexistent user

### DIFF
--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -293,6 +293,21 @@ var _ = Describe("Creating a container", func() {
 				Eventually(stdout).Should(gbytes.Say("vcap\n"))
 			})
 
+			It("and fails with a proper message if a username is given which does not exist", func() {
+				stderr := gbytes.NewBuffer()
+
+				process, err := container.Run(garden.ProcessSpec{
+					Path: "ls",
+					User: "asdf",
+				}, garden.ProcessIO{
+					Stderr: stderr,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(stderr).Should(gbytes.Say("ERROR: user asdf does not exist"))
+				Expect(process.Wait()).To(Equal(255))
+			})
+
 			Context("when root is requested", func() {
 				It("runs as root inside the container", func() {
 					stdout := gbytes.NewBuffer()

--- a/old/linux_backend/src/wsh/wshd.c
+++ b/old/linux_backend/src/wsh/wshd.c
@@ -333,7 +333,7 @@ int child_fork(msg_request_t *req, int in, int out, int err) {
 
     pw = getpwnam(user);
     if (pw == NULL) {
-      perror("getpwnam");
+      fprintf(stderr, "ERROR: user %s does not exist", req->user.name);
       goto error;
     }
 


### PR DESCRIPTION
it also refers to the bug on wsh in garden tracker [#92538672]
