### PR TITLE
Error gracefully when Run command cannot find the executable

### DIFF
--- a/integration/lifecycle/lifecycle_test.go
+++ b/integration/lifecycle/lifecycle_test.go
@@ -280,7 +280,22 @@ var _ = Describe("Creating a container", func() {
 		})
 
 		Context("and running a process", func() {
-			It("runs as the vcap user by default", func() {
+			It("fails to run with a proper message if a the given process is not found in $PATH", func() {
+				stderr := gbytes.NewBuffer()
+
+				process, err := container.Run(garden.ProcessSpec{
+					Path: "asdf",
+					Env:  []string{"PATH=/usr/sbin:/usr/bin:/sbin:/bin"},
+				}, garden.ProcessIO{
+					Stderr: stderr,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(stderr).Should(gbytes.Say("ERROR: could not find asdf in env PATH which is set to /usr/sbin:/usr/bin:/sbin:/bin"))
+				Expect(process.Wait()).To(Equal(255))
+			})
+
+			It("and runs as the vcap user by default", func() {
 				stdout := gbytes.NewBuffer()
 
 				_, err := container.Run(garden.ProcessSpec{

--- a/old/linux_backend/src/wsh/wshd.c
+++ b/old/linux_backend/src/wsh/wshd.c
@@ -387,7 +387,12 @@ int child_fork(msg_request_t *req, int in, int out, int err) {
     sigprocmask(SIG_SETMASK, &mask, NULL);
 
     execvpe(argv[0], argv, envp);
-    perror("execvpe");
+    if (ENOENT == errno){
+		fprintf(stderr, "ERROR: could not find %s in env PATH which is set to %s", argv[0], getenv("PATH"));
+	}
+	else{
+		fprintf(stderr, "ERROR: error running %s: %s", argv[0], strerror(errno));
+	}
 
 error:
     exit(255);


### PR DESCRIPTION
the error info is written on the forked process stderr stream, which is reported back to the client.