### PR TITLE
Ensure non-nil AuthConfig and HTTPRequestFactory values

### DIFF
--- a/old/repository_fetcher/repository_fetcher.go
+++ b/old/repository_fetcher/repository_fetcher.go
@@ -26,9 +26,6 @@ var RegistryNewEndpoint = registry.NewEndpoint
 // apes dockers registry.NewSession
 var RegistryNewSession = registry.NewSession
 
-// apes dockers registry.HTTPRequestFactory
-var RegistryHTTPRequestFactory = registry.HTTPRequestFactory
-
 // apes docker's *registry.Registry
 //go:generate counterfeiter . Registry
 type Registry interface {

--- a/old/repository_fetcher/repository_fetcher.go
+++ b/old/repository_fetcher/repository_fetcher.go
@@ -26,6 +26,9 @@ var RegistryNewEndpoint = registry.NewEndpoint
 // apes dockers registry.NewSession
 var RegistryNewSession = registry.NewSession
 
+// apes dockers registry.HTTPRequestFactory
+var RegistryHTTPRequestFactory = registry.HTTPRequestFactory
+
 // apes docker's *registry.Registry
 //go:generate counterfeiter . Registry
 type Registry interface {

--- a/old/repository_fetcher/repository_provider.go
+++ b/old/repository_fetcher/repository_provider.go
@@ -53,7 +53,7 @@ func (rp registryProvider) ProvideRegistry(hostname string) (Registry, error) {
 		return nil, err
 	}
 
-	return RegistryNewSession(nil, nil, endpoint, true)
+	return RegistryNewSession(&registry.AuthConfig{}, RegistryHTTPRequestFactory(nil), endpoint, true)
 }
 
 func NewRepositoryProvider(defaultHostname string, insecureRegistries []string) RegistryProvider {

--- a/old/repository_fetcher/repository_provider.go
+++ b/old/repository_fetcher/repository_provider.go
@@ -3,6 +3,9 @@ package repository_fetcher
 import (
 	"fmt"
 	"strings"
+
+        "github.com/docker/docker/registry"
+        "github.com/docker/docker/utils"
 )
 
 //go:generate counterfeiter . RegistryProvider
@@ -53,7 +56,7 @@ func (rp registryProvider) ProvideRegistry(hostname string) (Registry, error) {
 		return nil, err
 	}
 
-	return RegistryNewSession(&registry.AuthConfig{}, RegistryHTTPRequestFactory(nil), endpoint, true)
+	return RegistryNewSession(&registry.AuthConfig{}, &utils.HTTPRequestFactory{}, endpoint, true)
 }
 
 func NewRepositoryProvider(defaultHostname string, insecureRegistries []string) RegistryProvider {

--- a/old/repository_fetcher/repository_provider_test.go
+++ b/old/repository_fetcher/repository_provider_test.go
@@ -15,6 +15,8 @@ var _ = Describe("RepositoryProvider", func() {
 	var receivedHost string
 	var receivedInsecureRegistries []string
 	var receivedEndpoint *registry.Endpoint
+        var receivedAuthConfig *registry.AuthConfig
+        var receivedHTTPRequestFactory *utils.HTTPRequestFactory
 	var endpointReturnsError error
 	var sessionReturnsError error
 
@@ -25,6 +27,8 @@ var _ = Describe("RepositoryProvider", func() {
 		receivedHost = ""
 		receivedInsecureRegistries = nil
 		receivedEndpoint = nil
+                receivedAuthConfig = nil
+                receivedHTTPRequestFactory = nil
 
 		endpointReturnsError = nil
 		sessionReturnsError = nil
@@ -37,8 +41,10 @@ var _ = Describe("RepositoryProvider", func() {
 		}
 
 		returnedSession = &registry.Session{}
-		RegistryNewSession = func(_ *registry.AuthConfig, _ *utils.HTTPRequestFactory, endpoint *registry.Endpoint, _ bool) (*registry.Session, error) {
+		RegistryNewSession = func(authConfig *registry.AuthConfig, httpRequestFactory *utils.HTTPRequestFactory, endpoint *registry.Endpoint, _ bool) (*registry.Session, error) {
 			receivedEndpoint = endpoint
+                        receivedAuthConfig = authConfig
+                        receivedHTTPRequestFactory = httpRequestFactory
 			return returnedSession, sessionReturnsError
 		}
 	})
@@ -119,6 +125,8 @@ var _ = Describe("RepositoryProvider", func() {
 		Expect(session).To(Equal(returnedSession))
 
 		Expect(receivedEndpoint).To(Equal(returnedEndpoint))
+                Expect(receivedAuthConfig).ToNot(BeNil())
+                Expect(receivedHTTPRequestFactory).ToNot(BeNil())
 	})
 
 	Context("when NewSession returns an error", func() {


### PR DESCRIPTION
The version of the Docker dependency used currently requires a non-nil AuthConfig and HTTPRequestFactory in the NewSession call when TLS is used. This change provides empty, non-nil values for those items.

We submitted the corporate CLA for SAS Institute, Inc. yesterday to the contributors address at cloudfoundry.org.

This should fix both #31 and #27.