### PR TITLE
Ensure non-nil AuthConfig and HTTPRequestFactory values

### DIFF
--- a/repository_fetcher/repository_provider.go
+++ b/repository_fetcher/repository_provider.go
@@ -3,6 +3,8 @@ package repository_fetcher
 import (
 	"fmt"
 	"strings"
+        "github.com/docker/docker/registry"
+        "github.com/docker/docker/utils"
 )
 
 //go:generate counterfeiter . RegistryProvider
@@ -53,7 +55,7 @@ func (rp registryProvider) ProvideRegistry(hostname string) (Registry, error) {
 		return nil, err
 	}
 
-	return RegistryNewSession(nil, nil, endpoint, true)
+	return RegistryNewSession(&registry.AuthConfig{}, &utils.HTTPRequestFactory{}, endpoint, true)
 }
 
 func NewRepositoryProvider(defaultHostname string, insecureRegistries []string) RegistryProvider {

--- a/repository_fetcher/repository_provider_test.go
+++ b/repository_fetcher/repository_provider_test.go
@@ -15,6 +15,8 @@ var _ = Describe("RepositoryProvider", func() {
 	var receivedHost string
 	var receivedInsecureRegistries []string
 	var receivedEndpoint *registry.Endpoint
+        var receivedAuthConfig *registry.AuthConfig
+        var receivedHTTPRequestFactory *utils.HTTPRequestFactory
 	var endpointReturnsError error
 	var sessionReturnsError error
 
@@ -25,6 +27,8 @@ var _ = Describe("RepositoryProvider", func() {
 		receivedHost = ""
 		receivedInsecureRegistries = nil
 		receivedEndpoint = nil
+                receivedAuthConfig = nil
+                receivedHTTPRequestFactory = nil
 
 		endpointReturnsError = nil
 		sessionReturnsError = nil
@@ -37,8 +41,10 @@ var _ = Describe("RepositoryProvider", func() {
 		}
 
 		returnedSession = &registry.Session{}
-		RegistryNewSession = func(_ *registry.AuthConfig, _ *utils.HTTPRequestFactory, endpoint *registry.Endpoint, _ bool) (*registry.Session, error) {
+		RegistryNewSession = func(authConfig *registry.AuthConfig, httpRequestFactory *utils.HTTPRequestFactory, endpoint *registry.Endpoint, _ bool) (*registry.Session, error) {
 			receivedEndpoint = endpoint
+                        receivedAuthConfig = authConfig
+                        receivedHTTPRequestFactory = httpRequestFactory
 			return returnedSession, sessionReturnsError
 		}
 	})
@@ -119,6 +125,8 @@ var _ = Describe("RepositoryProvider", func() {
 		Expect(session).To(Equal(returnedSession))
 
 		Expect(receivedEndpoint).To(Equal(returnedEndpoint))
+                Expect(receivedAuthConfig).ToNot(BeNil())
+                Expect(receivedHTTPRequestFactory).ToNot(BeNil())
 	})
 
 	Context("when NewSession returns an error", func() {


### PR DESCRIPTION
The version of the Docker dependency used currently requires a non-nil AuthConfig and HTTPRequestFactory in the NewSession call when TLS is used. This change provides empty, non-nil values for those items.

This should fix both #31 and #27.

This is a resubmission of pull request 46 after receiving confirmation of our corporate CLA. That original PR was no longer merge-able due to file movement, so I've updated this set of changes to the new file locations.