### PR TITLE
Allow overriding DNS servers in containers

### DIFF
--- a/linux_backend/skeleton/setup.sh
+++ b/linux_backend/skeleton/setup.sh
@@ -122,13 +122,22 @@ cat > $rootfs_path/etc/hosts <<-EOS
 $network_container_ip $id
 EOS
 
+if [[ -n "${GARDEN_DNS_SERVERS}" ]]
+then
+  # A custom DNS server list was given; use that
+  rm -f $rootfs_path/etc/resolv.conf
+
+  for server in ${GARDEN_DNS_SERVERS}
+  do
+    echo "nameserver ${server}" >> $rootfs_path/etc/resolv.conf
+  done
+elif [[ "$(cat /etc/resolv.conf)" == "nameserver 127.0.0.1" ]]
 # By default, inherit the nameserver from the host container.
 #
 # Exception: When the host's nameserver is set to localhost (127.0.0.1), it is
 # assumed to be running its own DNS server and listening on all interfaces.
 # In this case, the container must use the network_host_ip address
 # as the nameserver.
-if [[ "$(cat /etc/resolv.conf)" == "nameserver 127.0.0.1" ]]
 then
   cat > $rootfs_path/etc/resolv.conf <<-EOS
 nameserver $network_host_ip

--- a/main.go
+++ b/main.go
@@ -241,6 +241,13 @@ func main() {
 		"Image which should never be garbage collected. (Can be specified multiple times)",
 	)
 
+    var dnsServers vars.StringList
+    flag.Var(
+        &dnsServers,
+        "dnsServer",
+        "DNS server IP address to use instead of automatically determined servers. (Can be specified multiple times)",
+    )
+
 	cf_debug_server.AddFlags(flag.CommandLine)
 	cf_lager.AddFlags(flag.CommandLine)
 	flag.Parse()
@@ -303,7 +310,7 @@ func main() {
 		return
 	}
 
-	config := sysconfig.NewConfig(*tag, *allowHostAccess)
+	config := sysconfig.NewConfig(*tag, *allowHostAccess, dnsServers.List)
 
 	runner := sysconfig.NewRunner(config, linux_command_runner.New())
 

--- a/resource_pool/resource_pool_test.go
+++ b/resource_pool/resource_pool_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Container pool", func() {
 		currentContainerVersion, err := semver.Make("1.0.0")
 		Expect(err).ToNot(HaveOccurred())
 
-		config = sysconfig.NewConfig("0", false)
+		config = sysconfig.NewConfig("0", false, nil)
 		logger = lagertest.NewTestLogger("test")
 		fakeMkdirChowner = new(fake_mkdir_chowner.FakeMkdirChowner)
 		pool = resource_pool.New(

--- a/sysconfig/config.go
+++ b/sysconfig/config.go
@@ -3,6 +3,7 @@ package sysconfig
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/cloudfoundry-incubator/garden-linux/process"
 )
@@ -13,6 +14,7 @@ type Config struct {
 	NetworkInterfacePrefix string
 	IPTables               IPTablesConfig
 	Tag                    string
+	DNSServers             []string
 }
 
 type IPTablesConfig struct {
@@ -34,10 +36,11 @@ type IPTablesNATConfig struct {
 	InstancePrefix   string
 }
 
-func NewConfig(tag string, allowHostAccess bool) Config {
+func NewConfig(tag string, allowHostAccess bool, dnsServers []string) Config {
 	return Config{
 		NetworkInterfacePrefix: fmt.Sprintf("w%s", tag),
-		Tag: tag,
+		Tag:        tag,
+		DNSServers: dnsServers,
 
 		CgroupPath:         fmt.Sprintf("/tmp/garden-%s/cgroup", tag),
 		CgroupNodeFilePath: "/proc/self/cgroup",
@@ -65,6 +68,7 @@ func (config Config) Environ() process.Env {
 
 		"GARDEN_NETWORK_INTERFACE_PREFIX": config.NetworkInterfacePrefix,
 		"GARDEN_TAG":                      config.Tag,
+		"GARDEN_DNS_SERVERS":              strings.Join(config.DNSServers, "\n"),
 
 		"GARDEN_IPTABLES_ALLOW_HOST_ACCESS":  strconv.FormatBool(config.IPTables.Filter.AllowHostAccess),
 		"GARDEN_IPTABLES_FILTER_INPUT_CHAIN": config.IPTables.Filter.InputChain,


### PR DESCRIPTION
See cloudfoundry-incubator/garden-linux#60 / cloudfoundry-incubator/guardian-release#7