### PR TITLE
handle grouped cgroup mounts (e.g. cpu,cpuacct)

### DIFF
--- a/linux_backend/bin/setup.sh
+++ b/linux_backend/bin/setup.sh
@@ -23,10 +23,14 @@ function mount_flat_cgroup() {
 
   # bind-mount cgroup subsystems to make file tree consistent
   for subsystem in $(tail -n +2 /proc/cgroups | awk '{print $1}'); do
-    mkdir -p ${1}/$subsystem
+    grouping=$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$subsystem\\>")
+    mkdir -p ${1}/$grouping
 
-    if ! mountpoint -q ${1}/$subsystem; then
-      mount --bind $1 ${1}/$subsystem
+    if ! mountpoint -q ${1}/$grouping; then
+      mount --bind $1 ${1}/$grouping
+    fi
+    if [ "$grouping" != "$subsystem" ]; then
+      ln -sf "${1}/$grouping" "${1}/$subsystem"
     fi
   done
 }
@@ -39,10 +43,14 @@ function mount_nested_cgroup() {
   fi
 
   for subsystem in $(tail -n +2 /proc/cgroups | awk '{print $1}'); do
-    mkdir -p ${1}/$subsystem
+    grouping=$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$subsystem\\>")
+    mkdir -p ${1}/$grouping
 
-    if ! mountpoint -q ${1}/$subsystem; then
-      mount -n -t cgroup -o $subsystem cgroup ${1}/$subsystem
+    if ! mountpoint -q ${1}/$grouping; then
+      mount -n -t cgroup -o $grouping cgroup ${1}/$grouping
+    fi
+    if [ "$grouping" != "$subsystem" ]; then
+      ln -sf "${1}/$grouping" "${1}/$subsystem"
     fi
   done
 }


### PR DESCRIPTION
While trying to get garden running on CoreOS I noticed that the linux_backend does not account for grouped cgroup mounts which seem to become more prevalent these days:
```
cat /proc/1/cgroup
9:perf_event:/
8:cpuset:/
7:devices:/
6:memory:/
5:freezer:/
4:cpu,cpuacct:/
3:blkio:/
2:net_cls,net_prio:/
1:name=systemd:/
```

The attached changes make garden-linux start in environments with multi cgroup mounts. For systems without multi group mounts this doesn't change anything.

