### PR TITLE
Add support for execveat syscall in case of ppc64 arch

### DIFF
--- a/linux_backend/src/nstar/nstar.c
+++ b/linux_backend/src/nstar/nstar.c
@@ -85,7 +85,11 @@ int mkdir_p_as(const char *dir, uid_t uid, gid_t gid) {
  * We need to define execveat here since glibc does not provide a wrapper
  * for this syscall yet. This code will not run once glibc implements this.
  */
+#if defined (__PPC64__)
+#define EXECVEAT_CODE 362
+#else
 #define EXECVEAT_CODE 322
+#endif
 int execveat(int fd, const char *path, char **argv, char **envp, int flags) {
     return syscall(EXECVEAT_CODE, fd, path, argv, envp, flags);
 }


### PR DESCRIPTION
Hi!
I am working on porting Cloud Foundry projects to Power microprocessor architecture.
For the ppc64 architecture execveat syscall has different code. I suggest to use `__PPC64__` macro to check and set the right value.