### PR TITLE
Remove destination filter from MASQUERADE rules

### DIFF
--- a/linux_container/iptables_manager/nat.go
+++ b/linux_container/iptables_manager/nat.go
@@ -38,9 +38,9 @@ func (mgr *natChain) Setup(containerID, bridgeName string, ip net.IP, network *n
 		exec.Command("iptables", "--wait", "--table", "nat", "-A", mgr.cfg.PreroutingChain, "--jump", instanceChain),
 		// Enable NAT for traffic coming from containers
 		exec.Command("sh", "-c", fmt.Sprintf(
-			`(iptables --wait --table nat -S %s | grep "\-j MASQUERADE\b" | grep -q -F -- "-s %s") || iptables --wait --table nat -A %s --source %s ! --destination %s --jump MASQUERADE`,
+			`(iptables --wait --table nat -S %s | grep "\-j MASQUERADE\b" | grep -q -F -- "-s %s") || iptables --wait --table nat -A %s --source %s --jump MASQUERADE`,
 			mgr.cfg.PostroutingChain, network.String(), mgr.cfg.PostroutingChain,
-			network.String(), network.String(),
+			network.String(),
 		)),
 	}
 

--- a/linux_container/iptables_manager/nat_test.go
+++ b/linux_container/iptables_manager/nat_test.go
@@ -64,9 +64,9 @@ var _ = Describe("natChain", func() {
 				fake_command_runner.CommandSpec{
 					Path: "sh",
 					Args: []string{"-c", fmt.Sprintf(
-						`(iptables --wait --table nat -S %s | grep "\-j MASQUERADE\b" | grep -q -F -- "-s %s") || iptables --wait --table nat -A %s --source %s ! --destination %s --jump MASQUERADE`,
+						`(iptables --wait --table nat -S %s | grep "\-j MASQUERADE\b" | grep -q -F -- "-s %s") || iptables --wait --table nat -A %s --source %s --jump MASQUERADE`,
 						testCfg.PostroutingChain, network.String(), testCfg.PostroutingChain,
-						network.String(), network.String(),
+						network.String(),
 					)},
 				},
 			}


### PR DESCRIPTION
When using DNAT rules to forward traffic for the
external IP of the garden host into one of the
containers, this now allows internal containers to
talk to the external address of that service successfully,
when that service is on the same subnet of the
internal container originating the request.

This should retain the features of MASQUERADE required
for multi-homed garden hosts, and not change the behavior
of direct intra-subnet communication for garden containers, or
direct communication across subnets for garden containers.
